### PR TITLE
Fixing issues with dynamic length

### DIFF
--- a/contracts/EtherRouter.sol
+++ b/contracts/EtherRouter.sol
@@ -28,4 +28,26 @@ contract EtherRouter {
       return(mload(0x40), outsize)
     }
   }
+
+  function getDynamicLength(address lengthDestination, bytes4 lengthSig, bytes msgData) returns(uint outsize) {
+    uint r;
+    bytes memory callData = msgData;
+    
+    // Replace signature in original calldata
+    callData[0] = lengthSig[0];
+    callData[1] = lengthSig[1];
+    callData[2] = lengthSig[2];
+    callData[3] = lengthSig[3];
+
+    // Make the call
+    assembly {
+      let len := mload(callData)
+      r := delegatecall(sub(gas, 700), lengthDestination, add(callData, 0x20), len, mload(0x40), 0x20)
+      outsize := mul(mload(mload(0x40)), 0x20)
+    }
+
+    // Throw if the call failed
+    if (r != 1) { throw;}
+  }
+
 }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -14,8 +14,9 @@ var TheNextAnswer = artifacts.require("TheNextAnswer.sol");
 var PayableContract = artifacts.require("PayableContract.sol");
 
 module.exports = function(deployer) {
+  deployer.deploy(Resolver,0)
   deployer.deploy([
-    Resolver,
+    
     TheAnswer,
     Multiplier,
     Lost,

--- a/test/ether_router.js
+++ b/test/ether_router.js
@@ -15,12 +15,14 @@ var PayableContract = artifacts.require("PayableContract.sol");
 
 contract('EtherRouter', function(accounts) {
   it("should be able to get back a return value", function(done) {
-    var resolver;
+    var resolver, ether_router;
 
     Resolver.new(0).
       then(function(result) { resolver = result }).
       then(function() { return EtherRouter.new(resolver.address); }).
-      then(function(ether_router) {
+      then(function(result) { ether_router = result }).
+      then(function() {return resolver.setRouter(ether_router.address)}).
+      then(function() {
         var fake_answer = TheAnswer.at(ether_router.address);
         TheAnswer.deployed().
           then(function(result) { return resolver.register("getAnswer()", result.address, 32); }).
@@ -34,12 +36,14 @@ contract('EtherRouter', function(accounts) {
   });
 
   it("should be able to pass along arguments", function(done) {
-    var resolver;
+    var resolver, ether_router;
 
     Resolver.new(0).
       then(function(result) { resolver = result }).
       then(function() { return EtherRouter.new(resolver.address); }).
-      then(function(ether_router) {
+      then(function(result) { ether_router = result }).
+      then(function() {return resolver.setRouter(ether_router.address)}).
+      then(function() {
         var fake_multiplier = Multiplier.at(ether_router.address);
         Multiplier.deployed().
           then(function(result) { return resolver.register("multiply(uint256,uint256)", result.address, 32); }).
@@ -52,12 +56,14 @@ contract('EtherRouter', function(accounts) {
   });
 
   it("should be able to get multiple return values", function(done) {
-    var resolver;
+    var resolver, ether_router;
 
     Resolver.new(0).
       then(function(result) { resolver = result }).
       then(function() { return EtherRouter.new(resolver.address); }).
-      then(function(ether_router) {
+      then(function(result) { ether_router = result }).
+      then(function() {return resolver.setRouter(ether_router.address)}).
+      then(function() {
         var fake_lost = Lost.at(ether_router.address);
         Lost.deployed().
           then(function(result) { return resolver.register("getNumbers()", result.address, 192); }).
@@ -75,13 +81,15 @@ contract('EtherRouter', function(accounts) {
   });
 
   it("should be able to store data", function(done) {
-    var resolver;
+    var resolver, ether_router;
     var simpleStore;
 
     Resolver.new(0).
       then(function(result) { resolver = result }).
       then(function() { return EtherRouter.new(resolver.address); }).
-      then(function(ether_router) {
+      then(function(result) { ether_router = result }).
+      then(function() {return resolver.setRouter(ether_router.address)}).
+      then(function() {
         var fake_simple_store = SimpleStore.at(ether_router.address);
         SimpleStore.deployed().
           then(function(result) { simpleStore = result; }).
@@ -97,12 +105,14 @@ contract('EtherRouter', function(accounts) {
   });
 
   it("should be able to read data on the contract", function(done) {
-    var resolver;
+    var resolver, ether_router;
 
     Resolver.new(0).
       then(function(result) { resolver = result }).
       then(function() { return EtherRouter.new(resolver.address); }).
-      then(function(ether_router) {
+      then(function(result) { ether_router = result }).
+      then(function() {return resolver.setRouter(ether_router.address)}).
+      then(function() {
         var fake_resolver_accessor = ResolverAccessor.at(ether_router.address);
         ResolverAccessor.deployed().
           then(function(result) { return resolver.register("getResolver()", result.address, 32); }).
@@ -115,12 +125,14 @@ contract('EtherRouter', function(accounts) {
   });
 
   it("should keep its msg.sender", function(done) {
-    var resolver;
+    var resolver, ether_router;
 
     Resolver.new(0).
       then(function(result) { resolver = result }).
       then(function() { return EtherRouter.new(resolver.address); }).
-      then(function(ether_router) {
+      then(function(result) { ether_router = result }).
+      then(function() {return resolver.setRouter(ether_router.address)}).
+      then(function() {
         var fake_sender_checker = SenderChecker.at(ether_router.address);
         SenderChecker.deployed().
           then(function(result) { return resolver.register("checkSender()", result.address, 32); }).
@@ -133,14 +145,16 @@ contract('EtherRouter', function(accounts) {
   });
 
   it("should allow upgrades that add storage data", function(done) {
-    var resolver;
+    var resolver, ether_router;
     var one;
     var two;
 
     Resolver.new(0).
       then(function(result) { resolver = result }).
       then(function() { return EtherRouter.new(resolver.address); }).
-      then(function(ether_router) {
+      then(function(result) { ether_router = result }).
+      then(function() {return resolver.setRouter(ether_router.address)}).
+      then(function() {
         var fake_one = One.at(ether_router.address);
         var fake_two = Two.at(ether_router.address);
         One.deployed().
@@ -166,13 +180,15 @@ contract('EtherRouter', function(accounts) {
   });
 
   it("should be able to use the fallback contract for unknown signatures", function(done) {
-    var resolver;
+    var resolver, ether_router;
     var theAnswer;
 
     Resolver.new(0).
       then(function(result) { resolver = result }).
       then(function() { return EtherRouter.new(resolver.address); }).
-      then(function(ether_router) {
+      then(function(result) { ether_router = result }).
+      then(function() {return resolver.setRouter(ether_router.address)}).
+      then(function() {
         var fake_answer = TheAnswer.at(ether_router.address);
         TheAnswer.deployed().
           then(function(result) { theAnswer = result; }).
@@ -188,13 +204,15 @@ contract('EtherRouter', function(accounts) {
 
   it("should allow variable-return functions to lookup their return size if possible", function(done) {
     var key = 42;
-    var resolver;
+    var resolver, ether_router;
     var list;
 
     Resolver.new(0).
       then(function(result) { resolver = result }).
       then(function() { return EtherRouter.new(resolver.address); }).
-      then(function(ether_router) {
+      then(function(result) { ether_router = result }).
+      then(function() {return resolver.setRouter(ether_router.address)}).
+      then(function() {
         var fake_list = List.at(ether_router.address);
         List.deployed().
           then(function(result) { list = result; }).
@@ -218,12 +236,14 @@ contract('EtherRouter', function(accounts) {
   });
 
   it("should propagate errors", function(done) {
-    var resolver;
+    var resolver, ether_router;
 
     Resolver.new(0).
       then(function(result) { resolver = result }).
       then(function() { return EtherRouter.new(resolver.address); }).
-      then(function(ether_router) {
+      then(function(result) { ether_router = result }).
+      then(function() {return resolver.setRouter(ether_router.address)}).
+      then(function() {
         var fake_thrower = Thrower.at(ether_router.address);
         Thrower.deployed().
           then(function(result) { return resolver.register("throws()", result.address, 0); }).
@@ -234,13 +254,15 @@ contract('EtherRouter', function(accounts) {
   });
 
   it("should be able to pass ether to payable functions", function(done) {
-    var resolver;
+    var resolver, ether_router;
     var payableContract;
 
     Resolver.new(0).
       then(function(result) { resolver = result }).
       then(function() { return EtherRouter.new(resolver.address); }).
-      then(function(ether_router) {
+      then(function(result) { ether_router = result }).
+      then(function() {return resolver.setRouter(ether_router.address)}).
+      then(function() {
         var fake_payable = PayableContract.at(ether_router.address);
         PayableContract.deployed().
           then(function(result) { payableContract = result; }).

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -48,6 +48,14 @@ contract('Resolver', function(accounts) {
       catch(done);
   });
 
+  it("shouldn't allow non-admins to change router", function(done) {
+    Resolver.new(0).
+      then(function(new_resolver) { resolver = new_resolver; }).
+      then(function() { return resolver.setRouter(0, {from: accounts[2]}) }).
+      then(assert.fail, function(err) { done(); }).
+      catch(done);
+  });
+
   it("should allow the admin to change the admin", function(done) {
     Resolver.new(0).
       then(function(new_resolver) { resolver = new_resolver; }).


### PR DESCRIPTION
First of all, let me say that this is a great project! I've been digging into the details, and I've noticed a couple of issues with getting dynamic length of return values:
1. Since the storage is actually on EtherRouter, the call to length sig should be made in the context of the Router, not Resolver. The values returned in tests were incorrect, since the queried variable mapped to Resolver storage.
2. As I understood from the code the call signature and length signature should share the same parameters, i.e. the data from original call. The length call in Resolver used calldata which at this moment referred to resolver.lookup() call, not the original call to EtherRouter.
This PR aims to solve both issues by moving the length call to EtherRouter and by using the calldata of the original call.